### PR TITLE
Add callback function for server authentication

### DIFF
--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/WinHttpClientEngineConfig.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/WinHttpClientEngineConfig.kt
@@ -6,6 +6,7 @@ package io.ktor.client.engine.winhttp
 
 import io.ktor.client.engine.*
 import io.ktor.http.*
+import kotlinx.cinterop.*
 
 public class WinHttpClientEngineConfig : HttpClientEngineConfig() {
 
@@ -25,4 +26,19 @@ public class WinHttpClientEngineConfig : HttpClientEngineConfig() {
      * A value that disables TLS verification for outgoing requests.
      */
     public var sslVerify: Boolean = true
+
+    /**
+     * Handles the challenge of HTTP responses.
+     */
+    @OptIn(ExperimentalForeignApi::class)
+    public var challengeHandler: ChallengeHandler? = null
+        private set
+
+    /**
+     * Sets the [block] as an HTTP request challenge handler.
+     */
+    @OptIn(ExperimentalForeignApi::class)
+    public fun handleChallenge(block: ChallengeHandler) {
+        challengeHandler = block
+    }
 }

--- a/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpRequest.kt
+++ b/ktor-client/ktor-client-winhttp/windows/src/io/ktor/client/engine/winhttp/internal/WinHttpRequest.kt
@@ -147,6 +147,7 @@ internal class WinHttpRequest(
             if (WinHttpReceiveResponse(hRequest, null) == 0) {
                 throw getWinHttpException(ERROR_FAILED_TO_RECEIVE_RESPONSE)
             }
+            config.challengeHandler?.invoke(hRequest)
         }
     }
 


### PR DESCRIPTION
**Subsystem**
Client/WinHttp

**Motivation**
There is no callback function used to handle server authentication. This is needed for the resolution of [XPOINT-8793](https://xpointtech.atlassian.net/browse/XPOINT-8793)

**Solution**
Add callback function to handle server authentication

